### PR TITLE
IOS-14036 [Crashlytics] [Linked Issue] [Foundation] -[NSMutableDictionary(NSMutableDictionary) initWithContentsOfFile:]

### DIFF
--- a/Sources/CartActionButton/CartActionButton.swift
+++ b/Sources/CartActionButton/CartActionButton.swift
@@ -567,13 +567,11 @@ private extension UIView {
 // MARK: - UIImage extension
 extension UIImage {
     static func from(color: UIColor) -> UIImage {
-        let rect = CGRect(x: 0, y: 0, width: 1, height: 1)
-        UIGraphicsBeginImageContext(rect.size)
-        let context = UIGraphicsGetCurrentContext()
-        context!.setFillColor(color.cgColor)
-        context!.fill(rect)
-        let img = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return img!
+        let size = CGSize(width: 1, height: 1)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            color.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
     }
 }


### PR DESCRIPTION
deprecated된 UIGraphicsBeginImageContext에서 UIGraphicsImageRenderer로 변경

https://console.firebase.google.com/u/0/project/yogiyo.co.kr:api-project-436880659021/crashlytics/app/ios:com.yogiyo.yogiyoapp/issues/cfc598765923997797ef2e15e592b3c3?utm_campaign=extensions&utm_medium=JIRA&utm_source=CRASHLYTICS_CONSOLE_MANUAL_ISSUE&time=last-seven-days&sessionEventKey=47f8a8bacc3d4f64a67a36d88a16fdbb_2081881999731131539