### PR TITLE
IOS-14094 [iOS] 요마트 CartActionButton + 버튼 클릭 영역 확장

### DIFF
--- a/Sources/CartActionButton/CartActionButton.swift
+++ b/Sources/CartActionButton/CartActionButton.swift
@@ -264,6 +264,10 @@ public class CartActionButton: UIView {
 
     public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         guard isExpanded else {
+            let pointInPlusContainer = plusBtnContainerView.convert(point, from: self)
+            if plusBtnContainerView.bounds.contains(pointInPlusContainer) {
+                return plusButton
+            }
             return super.hitTest(point, with: event)
         }
         guard point.y > 0 && point.y < bounds.height else {


### PR DESCRIPTION
plusBtnContainerView의 서브뷰로 plusButton이 존재하는 상태이고,
isExpanded == false일 때는 터치영역을 별도로 조정해주지 않아서 plusButton 이 아이콘 크기대로 터치 영역이 잡혀있음.
사용성을 개선하기 위해 plusBtnContainerView 전체로 터치 영역을 확장

![simulator_screenshot_80FA143E-D976-42A2-80C9-F84429233398](https://github.com/user-attachments/assets/c47c14cc-82e4-4ab3-9b0b-a4c073149e00)
